### PR TITLE
don't panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl Journal {
             ).unwrap(),
         ) {
             Ok(_) => Self {},
-            Err(_) => panic!("Journal already instantiated"),
+            Err(_) => Self {},
         }
     }
 


### PR DESCRIPTION
Ignores when a handle already exists, previous panic! prevented loading an already existent db